### PR TITLE
bugfix: enable web

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
-# uncomment when you add new bot
-# web: bundle exec ruby lib/motbot/web.rb
+web: bundle exec ruby lib/motbot/web.rb


### PR DESCRIPTION
it turns out that, as long as you have free dyno hours, the web app runs
30 minutes, and sleeps. the web is only necessary when you add another
account.